### PR TITLE
Add basic XMPP client

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'ui/chat_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,12 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'XMPP Jabber Client',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const ChatPage(),
     );
   }
 }

--- a/lib/ui/chat_page.dart
+++ b/lib/ui/chat_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../xmpp/xmpp_client.dart';
+
+class ChatPage extends StatefulWidget {
+  const ChatPage({super.key});
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  late XmppClient client;
+  final messageController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+
+    client = XmppClient(
+      jid: 'tucuenta@jabber.de',
+      password: 'tuclave',
+      domain: 'jabber.de',
+      websocketUrl: 'wss://jabber.de:443/xmpp-websocket',
+    );
+
+    client.connect();
+  }
+
+  void sendMessage() {
+    final message = messageController.text.trim();
+    if (message.isNotEmpty) {
+      client.sendMessage('otro@jabber.hot-chilli.net', message);
+      messageController.clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    client.disconnect();
+    messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('XMPP Chat')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: messageController,
+              decoration: const InputDecoration(labelText: 'Mensaje'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: sendMessage,
+              child: const Text('Enviar'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/xmpp/xmpp_client.dart
+++ b/lib/xmpp/xmpp_client.dart
@@ -1,0 +1,51 @@
+import 'package:web_socket_channel/web_socket_channel.dart';
+import 'xmpp_message.dart';
+
+class XmppClient {
+  final String jid;
+  final String password;
+  final String domain;
+  final String websocketUrl;
+
+  late WebSocketChannel _channel;
+
+  XmppClient({
+    required this.jid,
+    required this.password,
+    required this.domain,
+    required this.websocketUrl,
+  });
+
+  void connect() {
+    _channel = WebSocketChannel.connect(Uri.parse(websocketUrl));
+
+    _channel.stream.listen((data) {
+      print('[RECEIVED] $data');
+
+      if (data.toString().contains('<stream:features')) {
+        final auth = XmppMessage.buildAuthPlain(jid, password);
+        _channel.sink.add(auth);
+      }
+
+      if (data.toString().contains('<success')) {
+        print('[AUTH] Success');
+        _channel.sink.add(XmppMessage.buildStreamOpen(domain));
+      }
+    }, onError: (error) {
+      print('[ERROR] $error');
+    });
+
+    // Iniciar flujo
+    _channel.sink.add(XmppMessage.buildStreamOpen(domain));
+  }
+
+  void sendMessage(String toJid, String text) {
+    final message = XmppMessage.buildMessage(toJid, text);
+    _channel.sink.add(message);
+    print('[SEND] Message to $toJid');
+  }
+
+  void disconnect() {
+    _channel.sink.close();
+  }
+}

--- a/lib/xmpp/xmpp_message.dart
+++ b/lib/xmpp/xmpp_message.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'package:xml/xml.dart';
+
+class XmppMessage {
+  static String buildStreamOpen(String domain) {
+    return "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='$domain' version='1.0'/>";
+  }
+
+  static String buildAuthPlain(String jid, String password) {
+    final username = jid.split('@')[0];
+    final authStr = '\u0000$username\u0000$password';
+    final authB64 = base64Encode(utf8.encode(authStr));
+
+    final builder = XmlBuilder();
+    builder.element('auth', nest: () {
+      builder.attribute('xmlns', 'urn:ietf:params:xml:ns:xmpp-sasl');
+      builder.attribute('mechanism', 'PLAIN');
+      builder.text(authB64);
+    });
+    return builder.buildDocument().toXmlString();
+  }
+
+  static String buildMessage(String to, String text) {
+    final builder = XmlBuilder();
+    builder.element('message', nest: () {
+      builder.attribute('to', to);
+      builder.attribute('type', 'chat');
+      builder.element('body', nest: text);
+    });
+    return builder.buildDocument().toXmlString();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  web_socket_channel: ^2.4.0
+  xml: ^6.3.0
+  convert: ^3.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add dependencies for web socket & XML
- implement basic XMPP message builder and client
- provide simple chat interface
- wire up ChatPage in main app entrypoint
- fix XML framing string

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9eafae30832c93f2a5058cff2efe